### PR TITLE
docs: use relative project reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Milestone Pay is a Next.js foundation for AI delivery and bounty settlement scen
 
 ## Why this repository is ready for delivery
 
-- New-contributor-friendly entry point: this README + [Project Reference](/Users/fergus/WLFIAgent/milestone-bounty-pay/docs/README.md)
-- Single maintained documentation source: [Project Reference](/Users/fergus/WLFIAgent/milestone-bounty-pay/docs/README.md)
+- New-contributor-friendly entry point: this README + [Project Reference](docs/README.md)
+- Single maintained documentation source: [Project Reference](docs/README.md)
 - Setup, environment, architecture, database, demo, ops, and testing are all consolidated there
 - Engineering quality gates: `lint`, `typecheck`, `test`, `build`
 - Automated pipeline: GitHub Actions CI, runs `npm run ci` by default
@@ -67,7 +67,7 @@ tests/                   Basic unit tests
 
 ## Recommended Reading Order
 
-1. [Project Reference](/Users/fergus/WLFIAgent/milestone-bounty-pay/docs/README.md)
+1. [Project Reference](docs/README.md)
 
 ## Delivery Constraints
 


### PR DESCRIPTION
## Summary
- Replace README project-reference links that pointed to a contributor local absolute path with repository-relative links.
- Keeps the documentation entry point usable from GitHub and local clones.

## Verification
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck` (fails on existing TS errors unrelated to this README-only change: `route.ts` items on `never`, `tests/bounty-payout.test.ts` literal comparison)
- `npm run test` (fails on existing `tests/api/integrations-health-route.test.ts` expectations unrelated to this README-only change)

Closes #5

/claim #5
Wallet: 0xe2e86bdb8753c24032f2ad42b4c1bd9748385a7d