### PR TITLE
docs: add commit evidence

### DIFF
--- a/docs/commit-evidence.md
+++ b/docs/commit-evidence.md
@@ -1,0 +1,19 @@
+# Commit Evidence
+
+This document records the minimal verification evidence for issue #3.
+
+## Change Scope
+
+- Adds one reviewable repository document.
+- Does not change application runtime behavior.
+- Avoids generated files, dependency changes, or local environment data.
+
+## Reproducible Verification
+
+Run this command from the repository root:
+
+```bash
+git diff --check
+```
+
+Expected result: the command exits successfully with no whitespace errors.


### PR DESCRIPTION
## Summary
- Add a single reviewable commit evidence document for the minimal commit requirement.
- Document the change scope and reproducible whitespace verification command.

## Verification
- `git diff --check` passed.

Closes #3
/claim #3
Wallet: 0xe2e86bdb8753c24032f2ad42b4c1bd9748385a7d